### PR TITLE
Opt in biweekly participation, instead of opt out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+storage/

--- a/dist/bot.js
+++ b/dist/bot.js
@@ -1,14 +1,51 @@
 "use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
 exports.__esModule = true;
 var config_1 = require("./config");
-var CLIENT_1 = require("./CLIENT");
+var client_1 = require("./client");
 var messages_1 = require("./messages");
 var groups_1 = require("./groups");
 var node_process_1 = require("node:process");
+var fs_1 = require("fs");
 function handleError(message, metadata) {
     var prettyPrint = function (obj) { return JSON.stringify(obj || "", null, 2); };
     console.log(message, prettyPrint(metadata));
-    CLIENT_1.CLIENT.chat.postMessage({
+    client_1.CLIENT.chat.postMessage({
         token: config_1.CONFIG.botToken,
         channel: config_1.CONFIG.errorChannelId,
         text: message,
@@ -25,7 +62,9 @@ var tagGroup = function (memberIds) {
     return memberIds.map(function (id) { return "<@".concat(id, ">"); }).join(" ");
 };
 function postPrivateInitiationToChannel(channelId, memberIds) {
-    CLIENT_1.CLIENT.chat
+    console.log("MEEP");
+    console.log(memberIds);
+    client_1.CLIENT.chat
         .postMessage({
         token: config_1.CONFIG.botToken,
         channel: channelId,
@@ -42,11 +81,90 @@ function postPrivateInitiationToChannel(channelId, memberIds) {
         });
     });
 }
+function postChannelQuery(environment) {
+    var channelId = environment == config_1.ENVIRONMENTS.PRODUCTION
+        ? config_1.CONFIG.sparkConnectionsChannelId
+        : config_1.CONFIG.errorChannelId;
+    client_1.CLIENT.chat
+        .postMessage({
+        token: config_1.CONFIG.botToken,
+        channel: channelId,
+        unfurl_links: false,
+        unfurl_media: false,
+        text: messages_1.queryMessage
+    })
+        .then(function (message) {
+        console.log("Posting query for participation: ".concat(JSON.stringify(message)));
+        putQueryMessage(environment, message);
+        addSampleParticipationEmoji(message);
+    })["catch"](function (e) {
+        return handleError("Failed to post query message to channel.", {
+            channelId: channelId,
+            errorResponse: e
+        });
+    });
+}
+function addSampleParticipationEmoji(message) {
+    client_1.CLIENT.reactions.add({
+        timestamp: message.ts,
+        channel: message.channel,
+        name: config_1.PARTICIPATION_EMOJI
+    });
+}
+function queryMessageFilename(environment) {
+    return "./".concat(config_1.CONFIG.storageDir, "/").concat(environment, ".json");
+}
+function putQueryMessage(environment, message) {
+    // writeFileSync overwrites existing files
+    (0, fs_1.writeFileSync)(queryMessageFilename(environment), JSON.stringify(message));
+}
+function getStoredQueryMessage(environment) {
+    return JSON.parse((0, fs_1.readFileSync)(queryMessageFilename(environment), "utf8"));
+}
+/**
+ * Get folks who reacted to the messaging polling for active participation.
+ */
+function getQueryMessageReactors(environment) {
+    return __awaiter(this, void 0, void 0, function () {
+        var storedQueryMessage, searchTimestamp, queryMessageHisory, queryMessages, reactors, uniqueReactors;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    storedQueryMessage = getStoredQueryMessage(environment);
+                    if (!storedQueryMessage.channel || !storedQueryMessage.ts) {
+                        handleError("No valid stored query message found for environment: ".concat(environment, "."));
+                        return [2 /*return*/, []];
+                    }
+                    searchTimestamp = (parseFloat(storedQueryMessage.ts) + config_1.TIMESTAMP_EPSILON).toFixed(6);
+                    queryMessageHisory = client_1.CLIENT.conversations.history({
+                        channel: storedQueryMessage.channel,
+                        latest: "".concat(searchTimestamp),
+                        limit: 1
+                    });
+                    return [4 /*yield*/, queryMessageHisory];
+                case 1:
+                    queryMessages = (_a.sent()).messages;
+                    if (!queryMessages ||
+                        queryMessages.length == 0 ||
+                        !queryMessages[0].reactions) {
+                        handleError("Couldn't find fresh query message found for environment: ".concat(environment, ". Is the API request formatted correctly?"));
+                        return [2 /*return*/, []];
+                    }
+                    reactors = queryMessages[0].reactions
+                        .map(function (reac) { return (reac.users ? reac.users : []); })
+                        .reduce(function (prev, current) { return prev.concat(current); })
+                        .filter(function (user) { return !config_1.CONFIG.blackList.includes(user); });
+                    uniqueReactors = reactors.filter(function (item, index) { return reactors.indexOf(item) == index; });
+                    return [2 /*return*/, uniqueReactors];
+            }
+        });
+    });
+}
 function postChannelAnnouncement(environment) {
     var channelId = environment == config_1.ENVIRONMENTS.PRODUCTION
         ? config_1.CONFIG.sparkConnectionsChannelId
         : config_1.CONFIG.errorChannelId;
-    CLIENT_1.CLIENT.chat
+    client_1.CLIENT.chat
         .postMessage({
         token: config_1.CONFIG.botToken,
         channel: channelId,
@@ -69,7 +187,7 @@ function postPrivateInitiation(environment, memberIds) {
         case config_1.ENVIRONMENTS.PRODUCTION:
             // Open Direct Message between parties and post initiation
             var userList = function (memberIds) { return memberIds.join(","); };
-            CLIENT_1.CLIENT.conversations
+            client_1.CLIENT.conversations
                 .open({
                 token: config_1.CONFIG.botToken,
                 prevent_creation: false,
@@ -96,16 +214,32 @@ var ENVIRONMENT = node_process_1.argv[2];
 if (![config_1.ENVIRONMENTS.PRODUCTION, config_1.ENVIRONMENTS.TEST].includes(ENVIRONMENT)) {
     throw "Must specify a valid environment!";
 }
-// Send out Direct Message introductions
-(0, groups_1.getGroupedMemberIDs)()
-    .then(function (groups) {
-    groups.forEach(function (memberIds) {
-        console.log("Attempting ".concat(ENVIRONMENT, " initiation for: ") + memberIds);
-        postPrivateInitiation(ENVIRONMENT, memberIds);
+var MESSAGE_TYPE = node_process_1.argv[3];
+if (![config_1.MESSAGE_TYPES.QUERY, config_1.MESSAGE_TYPES.INVITE].includes(MESSAGE_TYPE)) {
+    throw "Must specify a valid message type to send! Use \"".concat(config_1.MESSAGE_TYPES.QUERY, "\" to poll for participation, or \"").concat(config_1.MESSAGE_TYPES.INVITE, "\" to send invitations to a connection.");
+}
+if (MESSAGE_TYPE === config_1.MESSAGE_TYPES.QUERY) {
+    postChannelQuery(ENVIRONMENT);
+}
+if (MESSAGE_TYPE === config_1.MESSAGE_TYPES.INVITE) {
+    // Send out Direct Message introductions
+    getQueryMessageReactors(ENVIRONMENT)
+        .then(function (reactorIds) {
+        (0, groups_1.getGroupedMemberIDs)(reactorIds)
+            .then(function (groups) {
+            groups.forEach(function (memberIds) {
+                console.log("Attempting ".concat(ENVIRONMENT, " initiation for: ") + memberIds);
+                postPrivateInitiation(ENVIRONMENT, memberIds);
+            });
+        })["catch"](function (e) {
+            return handleError("Failed to get groups of memberIds", { errorResponse: e });
+        });
+    })["catch"](function (e) {
+        return handleError("Failed to get reactors to the query message.", {
+            errorResponse: e
+        });
     });
-})["catch"](function (e) {
-    return handleError("Failed to get groups of memberIds", { errorResponse: e });
-});
-// Announce to the channel so no one is ever uncertain if they just
-// didn't get grouped on a particular round.
-postChannelAnnouncement(ENVIRONMENT);
+    // Announce to the channel so no one is ever uncertain if they just
+    // didn't get grouped on a particular round.
+    postChannelAnnouncement(ENVIRONMENT);
+}

--- a/dist/config.js
+++ b/dist/config.js
@@ -1,14 +1,15 @@
 "use strict";
 exports.__esModule = true;
-exports.ENVIRONMENTS = exports.CONFIG = void 0;
+exports.PARTICIPATION_EMOJI = exports.TIMESTAMP_EPSILON = exports.MESSAGE_TYPES = exports.ENVIRONMENTS = exports.CONFIG = void 0;
 exports.CONFIG = {
     botToken: process.env.SLACK_BOT_TOKEN,
     signingSecret: process.env.SLACK_SIGNING_SECRET,
+    storageDir: "storage",
     errorChannelId: "C04J2SP748M",
     sparkConnectionsChannelId: "C04AMJBCU4F",
     blackList: [
-        "U042H5S0K7E",
-        "U04BEPGCU0H", // legacy Donut user
+        "U04BEPGCU0H",
+        "U04ER03P6GL", // sparkbot
     ],
     targetGroupSize: 4
 };
@@ -16,3 +17,13 @@ exports.ENVIRONMENTS = {
     PRODUCTION: "production",
     TEST: "test"
 };
+exports.MESSAGE_TYPES = {
+    QUERY: "query",
+    INVITE: "invite"
+};
+// Timestamp tolerance with which we can
+// filter conversations down to a particular message timestamp.
+// Slack is dumb and doesn't allow retrieves via message IDs, we have
+// to retrieve by channel and timestamp.
+exports.TIMESTAMP_EPSILON = 1e-5;
+exports.PARTICIPATION_EMOJI = "hand";

--- a/dist/groups.js
+++ b/dist/groups.js
@@ -44,7 +44,7 @@ var client_1 = require("./client");
  * of size `targetGroupSize`, avoiding cases where you get groups without critical mass.
  */
 function getGroupSizes(totalMembers, targetGroupSize) {
-    var numGroups = Math.floor(totalMembers / targetGroupSize);
+    var numGroups = Math.max(Math.floor(totalMembers / targetGroupSize), 1);
     var remainder = totalMembers % targetGroupSize;
     // Keeping it pretty simple: spread the remainder over the groups of targetGroupSize.
     // This means targetGroupSize is effectively only a minimum bound.
@@ -118,20 +118,15 @@ function getAllMemberIds() {
         });
     });
 }
-function getGroupedMemberIDs() {
+function getGroupedMemberIDs(providedMemberIds) {
     return __awaiter(this, void 0, void 0, function () {
-        var memberIds, filteredMemberIds, shuffledMemberIds;
+        var filteredMemberIds, shuffledMemberIds;
         return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0: return [4 /*yield*/, getAllMemberIds()];
-                case 1:
-                    memberIds = _a.sent();
-                    filteredMemberIds = memberIds.filter(function (id) {
-                        return !config_1.CONFIG.blackList.includes(id);
-                    });
-                    shuffledMemberIds = shuffle(filteredMemberIds);
-                    return [2 /*return*/, group(shuffledMemberIds)];
-            }
+            filteredMemberIds = providedMemberIds.filter(function (id) {
+                return !config_1.CONFIG.blackList.includes(id);
+            });
+            shuffledMemberIds = shuffle(filteredMemberIds);
+            return [2 /*return*/, group(shuffledMemberIds)];
         });
     });
 }

--- a/dist/messages.js
+++ b/dist/messages.js
@@ -1,6 +1,7 @@
 "use strict";
 exports.__esModule = true;
-exports.jobAnnouncementMessage = exports.privateInitiation = void 0;
+exports.queryMessage = exports.jobAnnouncementMessage = exports.privateInitiation = void 0;
+var config_1 = require("./config");
 var randomItem = function (array) {
     return array[Math.floor(Math.random() * array.length)];
 };
@@ -298,3 +299,4 @@ var announcementEmoji = function () {
     return randomItem([":mega:", ":speaker:", ":loudspeaker:"]);
 };
 exports.jobAnnouncementMessage = "".concat(announcementEmoji(), " Sending a new batch of introductions! If you haven't received one, please tell a human.");
+exports.queryMessage = ":thinking_face: <!here> Are you available to connect some time in the next 2 weeks? If so, please raise your hand! :".concat(config_1.PARTICIPATION_EMOJI, ":");

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@slack/web-api": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.8.0.tgz",
-      "integrity": "sha512-DI0T7pQy2SM14s+zJKlarzkyOqhpu2Qk3rL19g+3m7VDZ+lSMB/dt9nwf3BZIIp49/CoLlBjEmKMoakm69OD4Q==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.8.1.tgz",
+      "integrity": "sha512-eMPk2S99S613gcu7odSw/LV+Qxr8A+RXvBD0GYW510wJuTERiTjP5TgCsH8X09+lxSumbDE88wvWbuFuvGa74g==",
       "dependencies": {
         "@slack/logger": "^3.0.0",
         "@slack/types": "^2.0.0",
@@ -65,9 +65,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.11.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
-      "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w=="
+      "version": "20.2.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ=="
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 ENVIRONMENT=$1
+MESSAGE_TYPE=$2
 
 ./compile.sh
-node dist/bot.js $ENVIRONMENT
+# Messages that poll for community interest are stored in local filestorage
+mkdir -p storage
+node dist/bot.js $ENVIRONMENT $MESSAGE_TYPE
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -40,8 +40,6 @@ function postPrivateInitiationToChannel(
   channelId: string,
   memberIds: Array<string>
 ) {
-  console.log("MEEP");
-  console.log(memberIds);
   CLIENT.chat
     .postMessage({
       token: CONFIG.botToken,

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,8 +1,20 @@
-import { CONFIG, ENVIRONMENTS } from "./config";
-import { CLIENT } from "./CLIENT";
-import { jobAnnouncementMessage, privateInitiation } from "./messages";
+import {
+  CONFIG,
+  ENVIRONMENTS,
+  MESSAGE_TYPES,
+  PARTICIPATION_EMOJI,
+  TIMESTAMP_EPSILON,
+} from "./config";
+import { CLIENT } from "./client";
+import {
+  queryMessage,
+  jobAnnouncementMessage,
+  privateInitiation,
+} from "./messages";
 import { getGroupedMemberIDs } from "./groups";
 import { argv } from "node:process";
+import { ChatPostMessageResponse } from "@slack/web-api";
+import { readFileSync, writeFileSync } from "fs";
 
 function handleError(message: string, metadata?: Object) {
   const prettyPrint = (obj?: Object) => JSON.stringify(obj || "", null, 2);
@@ -28,6 +40,8 @@ function postPrivateInitiationToChannel(
   channelId: string,
   memberIds: Array<string>
 ) {
+  console.log("MEEP");
+  console.log(memberIds);
   CLIENT.chat
     .postMessage({
       token: CONFIG.botToken,
@@ -45,6 +59,101 @@ function postPrivateInitiationToChannel(
         errorResponse: e,
       })
     );
+}
+
+function postChannelQuery(environment: string) {
+  const channelId =
+    environment == ENVIRONMENTS.PRODUCTION
+      ? CONFIG.sparkConnectionsChannelId
+      : CONFIG.errorChannelId;
+  CLIENT.chat
+    .postMessage({
+      token: CONFIG.botToken,
+      channel: channelId,
+      unfurl_links: false,
+      unfurl_media: false,
+      text: queryMessage,
+    })
+    .then((message: ChatPostMessageResponse) => {
+      console.log(
+        `Posting query for participation: ${JSON.stringify(message)}`
+      );
+      putQueryMessage(environment, message);
+      addSampleParticipationEmoji(message);
+    })
+    .catch((e) =>
+      handleError("Failed to post query message to channel.", {
+        channelId: channelId,
+        errorResponse: e,
+      })
+    );
+}
+
+function addSampleParticipationEmoji(message: ChatPostMessageResponse) {
+  CLIENT.reactions.add({
+    timestamp: message.ts,
+    channel: message.channel,
+    name: PARTICIPATION_EMOJI,
+  });
+}
+
+function queryMessageFilename(environment: string): string {
+  return `./${CONFIG.storageDir}/${environment}.json`;
+}
+
+function putQueryMessage(
+  environment: string,
+  message: ChatPostMessageResponse
+) {
+  // writeFileSync overwrites existing files
+  writeFileSync(queryMessageFilename(environment), JSON.stringify(message));
+}
+
+function getStoredQueryMessage(environment: string): ChatPostMessageResponse {
+  return JSON.parse(readFileSync(queryMessageFilename(environment), "utf8"));
+}
+
+/**
+ * Get folks who reacted to the messaging polling for active participation.
+ */
+async function getQueryMessageReactors(
+  environment: string
+): Promise<Array<string>> {
+  const storedQueryMessage = getStoredQueryMessage(environment);
+  if (!storedQueryMessage.channel || !storedQueryMessage.ts) {
+    handleError(
+      `No valid stored query message found for environment: ${environment}.`
+    );
+    return [];
+  }
+  // Slack's API only takes search timestamps with precision up to 6 digits.
+  const searchTimestamp = (
+    parseFloat(storedQueryMessage.ts) + TIMESTAMP_EPSILON
+  ).toFixed(6);
+  const queryMessageHisory = CLIENT.conversations.history({
+    channel: storedQueryMessage.channel,
+    latest: `${searchTimestamp}`,
+    limit: 1,
+  });
+  const queryMessages = (await queryMessageHisory).messages;
+  if (
+    !queryMessages ||
+    queryMessages.length == 0 ||
+    !queryMessages[0].reactions
+  ) {
+    handleError(
+      `Couldn't find fresh query message found for environment: ${environment}. Is the API request formatted correctly?`
+    );
+    return [];
+  }
+  const reactors = queryMessages[0].reactions
+    .map((reac) => (reac.users ? reac.users : []))
+    .reduce((prev, current) => prev.concat(current))
+    .filter((user) => !CONFIG.blackList.includes(user));
+  const uniqueReactors = reactors.filter(
+    (item, index) => reactors.indexOf(item) == index
+  );
+  return uniqueReactors;
 }
 
 function postChannelAnnouncement(environment: string) {
@@ -110,18 +219,39 @@ if (![ENVIRONMENTS.PRODUCTION, ENVIRONMENTS.TEST].includes(ENVIRONMENT)) {
   throw "Must specify a valid environment!";
 }
 
-// Send out Direct Message introductions
-getGroupedMemberIDs()
-  .then((groups) => {
-    groups.forEach((memberIds) => {
-      console.log(`Attempting ${ENVIRONMENT} initiation for: ` + memberIds);
-      postPrivateInitiation(ENVIRONMENT, memberIds);
-    });
-  })
-  .catch((e) =>
-    handleError("Failed to get groups of memberIds", { errorResponse: e })
-  );
+const MESSAGE_TYPE = argv[3];
+if (![MESSAGE_TYPES.QUERY, MESSAGE_TYPES.INVITE].includes(MESSAGE_TYPE)) {
+  throw `Must specify a valid message type to send! Use "${MESSAGE_TYPES.QUERY}" to poll for participation, or "${MESSAGE_TYPES.INVITE}" to send invitations to a connection.`;
+}
 
-// Announce to the channel so no one is ever uncertain if they just
-// didn't get grouped on a particular round.
-postChannelAnnouncement(ENVIRONMENT);
+if (MESSAGE_TYPE === MESSAGE_TYPES.QUERY) {
+  postChannelQuery(ENVIRONMENT);
+}
+
+if (MESSAGE_TYPE === MESSAGE_TYPES.INVITE) {
+  // Send out Direct Message introductions
+  getQueryMessageReactors(ENVIRONMENT)
+    .then((reactorIds) => {
+      getGroupedMemberIDs(reactorIds)
+        .then((groups) => {
+          groups.forEach((memberIds) => {
+            console.log(
+              `Attempting ${ENVIRONMENT} initiation for: ` + memberIds
+            );
+            postPrivateInitiation(ENVIRONMENT, memberIds);
+          });
+        })
+        .catch((e) =>
+          handleError("Failed to get groups of memberIds", { errorResponse: e })
+        );
+    })
+    .catch((e) =>
+      handleError("Failed to get reactors to the query message.", {
+        errorResponse: e,
+      })
+    );
+
+  // Announce to the channel so no one is ever uncertain if they just
+  // didn't get grouped on a particular round.
+  postChannelAnnouncement(ENVIRONMENT);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,12 @@
 export const CONFIG = {
   botToken: process.env.SLACK_BOT_TOKEN,
   signingSecret: process.env.SLACK_SIGNING_SECRET,
+  storageDir: "storage",
   errorChannelId: "C04J2SP748M", // #x0testing
   sparkConnectionsChannelId: "C04AMJBCU4F", // #13-spark-connections
   blackList: [
-    "U042H5S0K7E", // the Admin account
     "U04BEPGCU0H", // legacy Donut user
+    "U04ER03P6GL", // sparkbot
   ],
   targetGroupSize: 4,
 };
@@ -14,3 +15,16 @@ export const ENVIRONMENTS = {
   PRODUCTION: "production",
   TEST: "test",
 };
+
+export const MESSAGE_TYPES = {
+  QUERY: "query", // Poll for participation at the top of a week
+  INVITE: "invite", // Actually send out invitation to connect in Direct Messages
+};
+
+// Timestamp tolerance with which we can
+// filter conversations down to a particular message timestamp.
+// Slack is dumb and doesn't allow retrieves via message IDs, we have
+// to retrieve by channel and timestamp.
+export const TIMESTAMP_EPSILON = 1e-5;
+
+export const PARTICIPATION_EMOJI = "hand";

--- a/src/groups.ts
+++ b/src/groups.ts
@@ -12,7 +12,7 @@ function getGroupSizes(
   totalMembers: number,
   targetGroupSize: number
 ): Array<number> {
-  const numGroups = Math.floor(totalMembers / targetGroupSize);
+  const numGroups = Math.max(Math.floor(totalMembers / targetGroupSize), 1);
   const remainder = totalMembers % targetGroupSize;
 
   // Keeping it pretty simple: spread the remainder over the groups of targetGroupSize.
@@ -80,9 +80,10 @@ async function getAllMemberIds(): Promise<Array<string>> {
   return memberIds;
 }
 
-export async function getGroupedMemberIDs(): Promise<Groups> {
-  const memberIds = await getAllMemberIds();
-  const filteredMemberIds = memberIds.filter((id) => {
+export async function getGroupedMemberIDs(
+  providedMemberIds: string[]
+): Promise<Groups> {
+  const filteredMemberIds = providedMemberIds.filter((id) => {
     return !CONFIG.blackList.includes(id);
   });
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,4 +1,5 @@
 import { SectionBlock, DividerBlock } from "@slack/types";
+import { PARTICIPATION_EMOJI } from "./config";
 
 const randomItem = (array: Array<any>) =>
   array[Math.floor(Math.random() * array.length)];
@@ -336,4 +337,7 @@ export function privateInitiation(
 
 const announcementEmoji = () =>
   randomItem([":mega:", ":speaker:", ":loudspeaker:"]);
+
 export const jobAnnouncementMessage = `${announcementEmoji()} Sending a new batch of introductions! If you haven't received one, please tell a human.`;
+
+export const queryMessage = `:thinking_face: <!here> Are you available to connect some time in the next 2 weeks? If so, please raise your hand! :${PARTICIPATION_EMOJI}:`;


### PR DESCRIPTION
Instead of grouping up everyone in the channel, instead we group up people who explicitly opt in each period.

Concretely this means:
* There are now 2 script run types, a "query" that posts a message and asks for active participation, and an "invite" which sends invitations to those who participate
* Adding a storage director to locally store query message data for later reference