### PR TITLE
Time limit explicit in participation query message

### DIFF
--- a/dist/bot.js
+++ b/dist/bot.js
@@ -62,8 +62,6 @@ var tagGroup = function (memberIds) {
     return memberIds.map(function (id) { return "<@".concat(id, ">"); }).join(" ");
 };
 function postPrivateInitiationToChannel(channelId, memberIds) {
-    console.log("MEEP");
-    console.log(memberIds);
     client_1.CLIENT.chat
         .postMessage({
         token: config_1.CONFIG.botToken,

--- a/dist/messages.js
+++ b/dist/messages.js
@@ -299,4 +299,4 @@ var announcementEmoji = function () {
     return randomItem([":mega:", ":speaker:", ":loudspeaker:"]);
 };
 exports.jobAnnouncementMessage = "".concat(announcementEmoji(), " Sending a new batch of introductions! If you haven't received one, please tell a human.");
-exports.queryMessage = ":thinking_face: <!here> Are you available to connect some time in the next 2 weeks? If so, please raise your hand! :".concat(config_1.PARTICIPATION_EMOJI, ":");
+exports.queryMessage = ":thinking_face: <!here> Are you available to connect some time in the next 2 weeks? If so, please raise your hand *within 2 days*! :".concat(config_1.PARTICIPATION_EMOJI, ":");

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -340,4 +340,4 @@ const announcementEmoji = () =>
 
 export const jobAnnouncementMessage = `${announcementEmoji()} Sending a new batch of introductions! If you haven't received one, please tell a human.`;
 
-export const queryMessage = `:thinking_face: <!here> Are you available to connect some time in the next 2 weeks? If so, please raise your hand! :${PARTICIPATION_EMOJI}:`;
+export const queryMessage = `:thinking_face: <!here> Are you available to connect some time in the next 2 weeks? If so, please raise your hand *within 2 days*! :${PARTICIPATION_EMOJI}:`;


### PR DESCRIPTION
It's not altogether clear what the time horizon is where people should explicitly opt in. Now we give them 2 days.